### PR TITLE
Prevent child processes from ending up defunct

### DIFF
--- a/src/language/grammar.rs
+++ b/src/language/grammar.rs
@@ -176,7 +176,7 @@ impl GrammarSuggestions for AsyncGramchecker {
         &self,
         message: GramcheckRequest,
         language: &str,
-    ) -> Box<Future<Item = GramcheckOutput, Error = ApiError>> {
+    ) -> Box<dyn Future<Item = GramcheckOutput, Error = ApiError>> {
         let gramcheckers = self.gramcheckers.read();
 
         let gramchecker = match gramcheckers.get(language) {
@@ -203,7 +203,7 @@ impl GrammarSuggestions for AsyncGramchecker {
         )
     }
 
-    fn add(&self, language: &str, path: &str) -> Box<Future<Item = (), Error = ApiError>> {
+    fn add(&self, language: &str, path: &str) -> Box<dyn Future<Item = (), Error = ApiError>> {
         info!("Adding Grammar Checker for {}", language);
 
         let mut gramcheckers = self.gramcheckers.write();
@@ -220,7 +220,7 @@ impl GrammarSuggestions for AsyncGramchecker {
         Box::new(ok(()))
     }
 
-    fn remove(&self, language: &str) -> Box<Future<Item = (), Error = ApiError>> {
+    fn remove(&self, language: &str) -> Box<dyn Future<Item = (), Error = ApiError>> {
         info!("Removing Grammar Checker for {}", language);
 
         let mut gramcheckers = self.gramcheckers.write();

--- a/src/language/speller.rs
+++ b/src/language/speller.rs
@@ -100,7 +100,7 @@ impl SpellingSuggestions for AsyncSpeller {
         &self,
         message: SpellerRequest,
         language: &str,
-    ) -> Box<Future<Item = SpellerResponse, Error = ApiError>> {
+    ) -> Box<dyn Future<Item = SpellerResponse, Error = ApiError>> {
         let lock = self.spellers.read();
 
         let speller = match lock.get(language) {
@@ -127,7 +127,7 @@ impl SpellingSuggestions for AsyncSpeller {
         )
     }
 
-    fn add(&self, language: &str, path: &str) -> Box<Future<Item = (), Error = ApiError>> {
+    fn add(&self, language: &str, path: &str) -> Box<dyn Future<Item = (), Error = ApiError>> {
         info!("Adding Speller for {}", language);
 
         let mut lock = self.spellers.write();
@@ -149,7 +149,7 @@ impl SpellingSuggestions for AsyncSpeller {
         Box::new(ok(()))
     }
 
-    fn remove(&self, language: &str) -> Box<Future<Item = (), Error = ApiError>> {
+    fn remove(&self, language: &str) -> Box<dyn Future<Item = (), Error = ApiError>> {
         info!("Removing Speller for {}", language);
 
         let mut lock = self.spellers.write();

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
     system.run().unwrap();
 }
 
-fn get_config(matches: &ArgMatches) -> Config {
+fn get_config(matches: &ArgMatches<'_>) -> Config {
     let default_path = "config.toml";
     let divvun_env_var = "DIVVUN_API_CONFIG_PATH";
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -39,8 +39,8 @@ impl ResponseError for ApiError {
 }
 
 pub struct LanguageFunctions {
-    pub spelling_suggestions: Box<SpellingSuggestions>,
-    pub grammar_suggestions: Box<GrammarSuggestions>,
+    pub spelling_suggestions: Box<dyn SpellingSuggestions>,
+    pub grammar_suggestions: Box<dyn GrammarSuggestions>,
 }
 
 pub trait SpellingSuggestions: Send + Sync {
@@ -48,9 +48,9 @@ pub trait SpellingSuggestions: Send + Sync {
         &self,
         message: SpellerRequest,
         language: &str,
-    ) -> Box<Future<Item = SpellerResponse, Error = ApiError>>;
-    fn add(&self, language: &str, path: &str) -> Box<Future<Item = (), Error = ApiError>>;
-    fn remove(&self, language: &str) -> Box<Future<Item = (), Error = ApiError>>;
+    ) -> Box<dyn Future<Item = SpellerResponse, Error = ApiError>>;
+    fn add(&self, language: &str, path: &str) -> Box<dyn Future<Item = (), Error = ApiError>>;
+    fn remove(&self, language: &str) -> Box<dyn Future<Item = (), Error = ApiError>>;
 }
 
 pub trait GrammarSuggestions: Send + Sync {
@@ -58,20 +58,20 @@ pub trait GrammarSuggestions: Send + Sync {
         &self,
         message: GramcheckRequest,
         language: &str,
-    ) -> Box<Future<Item = GramcheckOutput, Error = ApiError>>;
-    fn add(&self, language: &str, path: &str) -> Box<Future<Item = (), Error = ApiError>>;
-    fn remove(&self, language: &str) -> Box<Future<Item = (), Error = ApiError>>;
+    ) -> Box<dyn Future<Item = GramcheckOutput, Error = ApiError>>;
+    fn add(&self, language: &str, path: &str) -> Box<dyn Future<Item = (), Error = ApiError>>;
+    fn remove(&self, language: &str) -> Box<dyn Future<Item = (), Error = ApiError>>;
 }
 
 pub trait UnhoistFutureExt<U, E> {
-    fn unhoist(self) -> Box<Future<Item = U, Error = E>>;
+    fn unhoist(self) -> Box<dyn Future<Item = U, Error = E>>;
 }
 
 impl<T: 'static, U: 'static, E: 'static> UnhoistFutureExt<U, E> for T
 where
     T: Future<Item = Result<U, E>, Error = E>,
 {
-    fn unhoist(self) -> Box<Future<Item = U, Error = E>> {
+    fn unhoist(self) -> Box<dyn Future<Item = U, Error = E>> {
         Box::new(self.and_then(|res| match res {
             Ok(result) => ok(result),
             Err(e) => err(e),

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -140,7 +140,7 @@ struct FileInfo<'a> {
     pub stem: &'a str,
 }
 
-fn get_file_info(original_path: &PathBuf) -> Option<FileInfo> {
+fn get_file_info(original_path: &PathBuf) -> Option<FileInfo<'_>> {
     let path = match original_path.to_str() {
         Some(path) => path,
         None => {


### PR DESCRIPTION
This waits for the sub-processes in `list_preferences` to exit and collects
their output. I've also taken the liberty of adding a second commit that
contains a bunch of fixes for warnings, courtesy of `cargo fix`.

r? @projektir